### PR TITLE
Bug fix: cast expires_in to int

### DIFF
--- a/aiohttp_oauth2_client/models/token.py
+++ b/aiohttp_oauth2_client/models/token.py
@@ -42,7 +42,7 @@ class Token(BaseModel):
         """
         if isinstance(data, dict):
             if "expires_at" not in data:
-                data["expires_at"] = int(time.time()) + data["expires_in"]
+                data["expires_at"] = int(time.time()) + int(data["expires_in"])
         return data
 
     def is_expired(self, early_expiry: int = 30) -> bool:


### PR DESCRIPTION
I've used an API where `expires_in` is a string, so this PR ensures that strings would be casted to integers